### PR TITLE
OpenCore not displayed (always Clover)

### DIFF
--- a/About This Hack/HardwareCollector.swift
+++ b/About This Hack/HardwareCollector.swift
@@ -132,7 +132,7 @@ echo "$(cat ~/.ath/scrXml.txt | grep -A2 "</data>" | awk -F'>|<' '/_name/{getlin
         opencore2 = run("nvram 4D1FDA02-38C7-4A6A-9CC6-4BCCA8B30102:opencore-version | cut -c 60- | cut -c -1 | tr -d '\n'")
         opencore3 = run("nvram 4D1FDA02-38C7-4A6A-9CC6-4BCCA8B30102:opencore-version | cut -c 61- | cut -c -1 | tr -d '\n'")
         opencoreType = run("nvram 4D1FDA02-38C7-4A6A-9CC6-4BCCA8B30102:opencore-version | cut -c 55- | cut -c -3 | tr -d '\n'")
-        if opencore2.contains("0") || opencore2.contains("1"){
+        if opencore1.contains("0") || opencore1.contains("1"){
             if opencoreType.contains("REL") {
                 opencoreType = "(Release)"
             } else if opencoreType.contains("N/A") {

--- a/About This Hack/HardwareCollector.swift
+++ b/About This Hack/HardwareCollector.swift
@@ -132,7 +132,7 @@ echo "$(cat ~/.ath/scrXml.txt | grep -A2 "</data>" | awk -F'>|<' '/_name/{getlin
         opencore2 = run("nvram 4D1FDA02-38C7-4A6A-9CC6-4BCCA8B30102:opencore-version | cut -c 60- | cut -c -1 | tr -d '\n'")
         opencore3 = run("nvram 4D1FDA02-38C7-4A6A-9CC6-4BCCA8B30102:opencore-version | cut -c 61- | cut -c -1 | tr -d '\n'")
         opencoreType = run("nvram 4D1FDA02-38C7-4A6A-9CC6-4BCCA8B30102:opencore-version | cut -c 55- | cut -c -3 | tr -d '\n'")
-        if opencore1.contains("0") {
+        if opencore2.contains("0") || opencore2.contains("1"){
             if opencoreType.contains("REL") {
                 opencoreType = "(Release)"
             } else if opencoreType.contains("N/A") {


### PR DESCRIPTION
Good afternoon, latest commit works fine but I see Clover as boot loader despite I am on OpenCore now.

I guess that `getOpenCore()` fails in the line `if opencore1.contains("0"){`

OpenCore versions can have 0 or 1 as first character, this can be fixed changing the line to
`if opencore1.contains("0") || opencore1.contains("1"){`

With this modification, I get `OpenCore 1.0.3 (Release)` as expected.

Excuse me if I'm wrong, remember I'm not a coder like you.
